### PR TITLE
Ability to save empty relationship properties

### DIFF
--- a/src/includes/admin/class-papi-admin-meta-boxes.php
+++ b/src/includes/admin/class-papi-admin-meta-boxes.php
@@ -117,13 +117,10 @@ class Papi_Admin_Meta_Boxes {
 
 			$property_key = str_replace( $property_type_key, '', $key );
 
-			// Check if value exists.
-			if ( isset( $data[ $property_key ] ) ) {
-				$data[ $property_key ] = array(
-					'type'  => $value,
-					'value' => $data[ $property_key ]
-				);
-			}
+			$data[ $property_key ] = array(
+				'type'  => $value,
+				'value' => isset( $data[ $property_key ] ) ? $data[ $property_key ] : ''
+			);
 
 			unset( $data[ $key ] );
 		}


### PR DESCRIPTION
When we have a relationship property, e. g., of posts, and when we clear all the selected posts and click update/publish, the previous selected posts remain selected.
This PR adds the ability to save empty selections for those properties.