### PR TITLE
Fixed Repeater counter bug. Reseting 'counter' for each repeater propert...

### DIFF
--- a/src/includes/properties/class-papi-property-repeater.php
+++ b/src/includes/properties/class-papi-property-repeater.php
@@ -117,6 +117,7 @@ class Papi_Property_Repeater extends Papi_Property {
 		$values          = $this->get_value();
 
 		$settings->items = $this->prepare_properties( papi_to_array( $settings->items ) );
+		$this->counter = 0;
 		?>
 
 		<div class="papi-property-repeater">


### PR DESCRIPTION
When I've try to use more than one repeater properties on one edit page - row counter of second repeater was start from N+1. Where N - is last index from first repeater property. And the same for third etc...

Then I've used three repeaters in one page and after saving content from 2nd or 3rn repeater is gone.

So this simple fix resolved both problems.