### PR TITLE
Fix deprecated warning in jQuery Migrate

### DIFF
--- a/src/assets/js/packages/papi/properties/image.js
+++ b/src/assets/js/packages/papi/properties/image.js
@@ -42,7 +42,7 @@ class Image {
       self.add($(this));
     });
 
-    $(document).on('hover', '.papi-property-image .attachment', this.hover);
+    $(document).on('mouseenter mouseleave', '.papi-property-image .attachment', this.hover);
     $(document).on('click', '.papi-property-image .attachment a', this.remove);
     $(document).on('papi/property/repeater/added', '[data-property="image"]', this.update);
     $(document).on('click', '.papi-property-image .attachment', this.replace);


### PR DESCRIPTION
WP 3.6+ loads jquery-migrate and that gives a depraction warning about hover event.
``JQMIGRATE: 'hover' pseudo-event is deprecated, use 'mouseenter mouseleave' ``