### PR TITLE
Make papi handle false bool as empty

### DIFF
--- a/src/properties/class-papi-property-bool.php
+++ b/src/properties/class-papi-property-bool.php
@@ -86,6 +86,23 @@ class Papi_Property_Bool extends Papi_Property {
 	}
 
 	/**
+	 * Prepare property value.
+	 *
+	 * @param  mixed $value
+	 *
+	 * @return mixed
+	 */
+	public function prepare_value( $value ) {
+		if ( is_string( $value ) &&
+			( $value === 'true' || $value === 'on' ) ||
+			$value === true ) {
+			return true;
+		}
+
+		return null;
+	}
+
+	/**
 	 * Fix the database value on update.
 	 *
 	 * @param  mixed  $value
@@ -95,6 +112,6 @@ class Papi_Property_Bool extends Papi_Property {
 	 * @return array
 	 */
 	public function update_value( $value, $slug, $post_id ) {
-		return $this->format_value( $value, $slug, $post_id );
+		return $this->prepare_value( $value );
 	}
 }

--- a/tests/cases/properties/class-papi-property-bool-test.php
+++ b/tests/cases/properties/class-papi-property-bool-test.php
@@ -52,11 +52,11 @@ class Papi_Property_Bool_Test extends Papi_Property_Test_Case {
 	}
 
 	public function test_property_update_value() {
-		$this->assertFalse( $this->property->update_value( 'false', '', 0 ) );
-		$this->assertFalse( $this->property->update_value( '', '', 0 ) );
-		$this->assertFalse( $this->property->update_value( null, '', 0 ) );
-		$this->assertFalse( $this->property->update_value( (object) [], '', 0 ) );
-		$this->assertFalse( $this->property->update_value( [], '', 0 ) );
+		$this->assertNull( $this->property->update_value( 'false', '', 0 ) );
+		$this->assertNull( $this->property->update_value( '', '', 0 ) );
+		$this->assertNull( $this->property->update_value( null, '', 0 ) );
+		$this->assertNull( $this->property->update_value( (object) [], '', 0 ) );
+		$this->assertNull( $this->property->update_value( [], '', 0 ) );
 		$this->assertTrue( $this->property->update_value( 'true', '', 0 ) );
 		$this->assertTrue( $this->property->update_value( true, '', 0 ) );
 	}

--- a/tests/cases/properties/class-papi-property-repeater-test.php
+++ b/tests/cases/properties/class-papi-property-repeater-test.php
@@ -136,7 +136,7 @@ class Papi_Property_Repeater_Test extends Papi_Property_Test_Case {
 		$output   = $this->property->update_value( $input, 'test', $this->post_id );
 		$expected = [
 			'test_0_book_name' => 'Harry Potter',
-			'test_0_is_open'   => false,
+			'test_0_is_open'   => null,
 			'test'             => 1
 		];
 		$this->assertSame( $expected, $output );


### PR DESCRIPTION
To simplify WP meta-queries to handle false as nonexisting values instead of both nonexisting and false.