### PR TITLE
Save metaboxes on action edit_attachment

### DIFF
--- a/src/admin/class-papi-admin-post-handler.php
+++ b/src/admin/class-papi-admin-post-handler.php
@@ -59,10 +59,14 @@ final class Papi_Admin_Post_Handler extends Papi_Core_Data_Handler {
 	 * @param int    $post_id
 	 * @param object $post
 	 */
-	public function save_meta_boxes( $post_id, $post ) {
+	public function save_meta_boxes( $post_id, $post = null ) {
 		// Can't proceed without a post id or post.
-		if ( empty( $post_id ) || empty( $post ) ) {
+		if ( empty( $post_id ) ) {
 			return;
+		}
+
+		if ( empty( $post ) ) {
+			$post = get_post( $post_id );
 		}
 
 		// Don't save meta boxes for revisions or autosaves
@@ -123,6 +127,7 @@ final class Papi_Admin_Post_Handler extends Papi_Core_Data_Handler {
 	 */
 	private function setup_actions() {
 		add_action( 'save_post', [$this, 'save_meta_boxes'], 1, 2 );
+		add_action( 'edit_attachment', [$this, 'save_meta_boxes'], 1 );
 	}
 
 	/**

--- a/tests/cases/admin/class-papi-admin-post-handler-test.php
+++ b/tests/cases/admin/class-papi-admin-post-handler-test.php
@@ -38,6 +38,7 @@ class Papi_Admin_Post_Handler_Test extends WP_UnitTestCase {
 
 	public function test_actions() {
 		$this->assertGreaterThan( 0, has_action( 'save_post', [$this->handler, 'save_meta_boxes'] ) );
+		$this->assertGreaterThan( 0, has_action( 'edit_attachment', [$this->handler, 'save_meta_boxes'] ) );
 	}
 
 	public function test_save_meta_boxes() {


### PR DESCRIPTION
Attachments doesn't call the save_post action.