### PR TITLE
Remove PHP 5.4 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,6 @@ matrix:
     - php: 7.0
       env: WP_VERSION=nightly WP_MULTISITE=0
   allow_failures:
-    - php: 5.4
-      env: WP_VERSION=nightly WP_MULTISITE=0
     - php: 7.0
       env: WP_VERSION=nightly WP_MULTISITE=0
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ env:
 
 matrix:
   include:
-    - php: 5.4
-      env: WP_VERSION=latest WP_MULTISITE=0
     - php: 5.5
       env: WP_VERSION=4.0 WP_MULTISITE=0
     - php: 5.6


### PR DESCRIPTION
5.5 is required since f0b162717251481f00f3423af1034da3b902e5d0