### PR TITLE
#116 - Add nl2br setting to text property

### DIFF
--- a/src/properties/class-papi-property-text.php
+++ b/src/properties/class-papi-property-text.php
@@ -24,6 +24,8 @@ class Papi_Property_Text extends Papi_Property {
 			}
 
 			$value = wp_strip_all_tags( $value );
+			$value = $this->get_setting( 'nl2br' ) ? nl2br( $value ) : $value;
+
 		}
 
 		return $value;
@@ -36,7 +38,8 @@ class Papi_Property_Text extends Papi_Property {
 	 */
 	public function get_default_settings() {
 		return [
-			'allow_html' => false
+			'allow_html' => false,
+			'nl2br' => true,
 		];
 	}
 

--- a/tests/cases/properties/class-papi-property-text-test.php
+++ b/tests/cases/properties/class-papi-property-text-test.php
@@ -32,6 +32,7 @@ class Papi_Property_Text_Test extends Papi_Property_Test_Case {
 		$this->assertSame( $this->get_expected( 'text_html_test' ), $this->properties[1]->format_value( $this->get_value( 'text_html_test' ), '', 0 ) );
 		$this->assertSame( 'Hello', $this->properties[0]->format_value( '<p>Hello</p>', '', 0 ) );
 		$this->assertSame( '<p>Hello</p>', $this->properties[1]->format_value( '<p>Hello</p>', '', 0 ) );
+		$this->assertSame( "Hello<br />\nWorld", $this->properties[0]->format_value( "Hello\nWorld", '', 0 ) );
 	}
 
 	public function test_property_import_value() {


### PR DESCRIPTION
Ok, finally got it working. Sorry, I'm not familiar with unit testing and struggled a little bit with it. 

Am I wrong or is the test case for text property isn't testing settings at all (allow_html)? I also noticed another notice regarding the `papi_nl2br` but I will address you an specific issue on this. 

I also set the default nl2br setting to `true`, which seems the best behaviour according to me (regular users don't understand why a line break in a textarea don't show as a line break on the front end). I don't know you feel about this. I can change it if you see things differently. 