### PR TITLE
Fix PHP version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "issues": "https://github.com/wp-papi/papi/issues"
   },
   "require": {
-    "php": ">=5.5.9|^7.0"
+    "php": "^5.5.9 || ^7.0"
   },
   "require-dev": {
     "frozzare/wp-test-suite": "~1.0",


### PR DESCRIPTION
`>=5.5.9` will make `^7.0` useless. Instead use caret on both versions.