### PR TITLE
Remove support link

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,6 @@
     "page type",
     "page"
   ],
-  "support": {
-    "issues": "https://github.com/wp-papi/papi/issues"
-  },
   "require": {
     "php": "^5.5.9 || ^7.0"
   },


### PR DESCRIPTION
This isn't necessary when the issues are on GitHub.