### PR TITLE
Fix for deleted page types

### DIFF
--- a/src/lib/types/entry.php
+++ b/src/lib/types/entry.php
@@ -127,6 +127,10 @@ function papi_get_entry_type( $file_path ) {
 		}
 		// @codeCoverageIgnoreEnd
 
+		if ( ! class_exists( $class_name ) ) {
+			return;
+		}
+
 		$rc         = new ReflectionClass( $class_name );
 		$entry_type = $rc->newInstanceArgs( [$file_path] );
 


### PR DESCRIPTION
A fix for when class is never loaded, occurs when it tries to load an invalid value from _papi_page_type meta as a class.