### PR TITLE
Fix add new link

### DIFF
--- a/src/admin/class-papi-admin-menu.php
+++ b/src/admin/class-papi-admin-menu.php
@@ -152,7 +152,11 @@ final class Papi_Admin_Menu {
 				$submenu[$edit_url][10][2] = papi_get_page_new_url(
 					$only_page_type,
 					false,
-					$post_type
+					$post_type,
+					[
+						'post_parent',
+						'lang'
+					]
 				);
 			} else {
 				$page  = 'papi-add-new-page,' . $post_type;

--- a/src/admin/class-papi-admin-menu.php
+++ b/src/admin/class-papi-admin-menu.php
@@ -152,14 +152,7 @@ final class Papi_Admin_Menu {
 				$submenu[$edit_url][10][2] = papi_get_page_new_url(
 					$only_page_type,
 					false,
-					$post_type,
-					[
-						'action',
-						'message',
-						'page_type',
-						'post',
-						'post_type'
-					]
+					$post_type
 				);
 			} else {
 				$page  = 'papi-add-new-page,' . $post_type;

--- a/tests/cases/lib/core/url-test.php
+++ b/tests/cases/lib/core/url-test.php
@@ -21,29 +21,6 @@ class Papi_Lib_Core_Url_Test extends WP_UnitTestCase {
 		$this->assertNotFalse( strpos( $url, 'page_type=page&post_type=page' ) );
 	}
 
-	public function test_papi_get_page_query_strings() {
-		$this->assertEmpty( papi_get_page_query_strings() );
-
-		$old_request_uri = $_SERVER['REQUEST_URI'];
-
-		$_SERVER['REQUEST_URI'] = '/?page_id=63';
-		$this->assertSame( '&page_id=63&post_type=post', papi_get_page_query_strings() );
-
-		$_SERVER['REQUEST_URI'] = 'http://wordpress/wp-admin/edit.php?post_type=page&page=papi-add-new-page,page';
-		$this->assertSame( '&post_type=page', papi_get_page_query_strings() );
-
-		$_SERVER['REQUEST_URI'] = 'http://wordpress/wp-admin/edit.php?post_type=page&page';
-		$this->assertSame( '&post_type=page&page', papi_get_page_query_strings() );
-
-		$_SERVER['REQUEST_URI'] = 'http://wordpress/wp-admin/edit.php?post_type=page&page_type=simple-page-type&&';
-		$this->assertSame( '?page_type=simple-page-type', papi_get_page_query_strings( '?', ['post_type'] ) );
-
-		$_SERVER['REQUEST_URI'] = 'http://wordpress/wp-admin/edit.php?&';
-		$this->assertSame( '&post_type=post', papi_get_page_query_strings() );
-
-		$_SERVER['REQUEST_URI'] = $old_request_uri;
-	}
-
 	public function test_papi_append_post_type_query() {
 		global $post;
 
@@ -58,5 +35,30 @@ class Papi_Lib_Core_Url_Test extends WP_UnitTestCase {
 	public function test_papi_append_post_type_query_fail() {
 		$url = papi_append_post_type_query( 'http://wordpress/?post_parent=1' );
 		$this->assertSame( 'http://wordpress/?post_parent=1&post_type=post', $url );
+	}
+
+	public function test_papi_include_query_strings() {
+		$this->assertEmpty( papi_include_query_strings() );
+
+		$old_get = $_GET;
+
+		$_GET = [
+			'foo'=>'bar',
+			'baz'=>'boom',
+			'cow'=>'milk',
+			'php'=>'hypertext processor'
+		];
+
+		$this->assertEmpty( papi_include_query_strings( '?' ) );
+
+		$this->assertSame( '?foo=bar', papi_include_query_strings( '?', [ 'foo' ] ) );
+
+		$this->assertSame( '&baz=boom', papi_include_query_strings( '&', [ 'baz' ] ) );
+
+		$this->assertSame( '?foo=bar&baz=boom', papi_include_query_strings( '?', [ 'foo', 'baz' ] ) );
+
+		$this->assertSame( '?php=hypertext+processor', papi_include_query_strings( '?', [ 'php' ] ) );
+
+		$_GET = $old_get;
 	}
 }

--- a/tests/cases/lib/core/url-test.php
+++ b/tests/cases/lib/core/url-test.php
@@ -43,13 +43,15 @@ class Papi_Lib_Core_Url_Test extends WP_UnitTestCase {
 		$old_get = $_GET;
 
 		$_GET = [
-			'foo'=>'bar',
-			'baz'=>'boom',
-			'cow'=>'milk',
-			'php'=>'hypertext processor'
+			'foo' => 'bar',
+			'baz' => 'boom',
+			'cow' => 'milk',
+			'php' => 'hypertext processor'
 		];
 
 		$this->assertEmpty( papi_include_query_strings( '?' ) );
+
+		$this->assertEmpty( papi_include_query_strings( '?', [ 'missing' ] ) );
 
 		$this->assertSame( '?foo=bar', papi_include_query_strings( '?', [ 'foo' ] ) );
 


### PR DESCRIPTION
Changes papi_get_page_new_url so that it has an option to include existing query string instead of exclude. Fixes a bug where invalid links were created when visiting certain wp-admin urls.

Added new tests and removed papi_get_page_query_strings function since it's never used anymore. 