### PR TITLE
Test against 5.5.9 (WIP)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ cache:
 
 matrix:
   include:
+    - php: 5.5.9
+      env: WP_VERSION=4.0 WP_MULTISITE=0
     - php: 5.5
       env: WP_VERSION=4.0 WP_MULTISITE=0
     - php: 5.6


### PR DESCRIPTION
Since 5.5.9 is the lowest requirement we should also test against it.