### PR TITLE
Optimize papi_is_empty check for arrays

### DIFF
--- a/src/lib/core/utilities.php
+++ b/src/lib/core/utilities.php
@@ -420,9 +420,12 @@ function papi_html_tag( $tag, $attr = [] ) {
  */
 function papi_is_empty( $obj ) {
 	if ( is_array( $obj ) ) {
-		$obj = array_filter( $obj, function ( $val ) {
-			return ! papi_is_empty( $val );
-		} );
+		foreach ( $obj as $val ) {
+			if ( ! papi_is_empty( $val ) ) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	if ( is_string( $obj ) ) {


### PR DESCRIPTION
### Description

An array is not empty if one of the values is not empty, therefore we should not loop thru the whole array if not necessary. 

This change makes a huge speed improvement for papi_is_empty, in my tests from an improvement of 96%.
