### PR TITLE
Add support for turning off property cache and introduce a new filter

### DIFF
--- a/src/core/class-papi-core-meta-store.php
+++ b/src/core/class-papi-core-meta-store.php
@@ -222,6 +222,34 @@ abstract class Papi_Core_Meta_Store {
 	abstract public function get_property( $slug, $child_slug = '' );
 
 	/**
+	 * Get property option or default value.
+	 *
+	 * @param  string $slug
+	 * @param  string $option
+	 * @param  mixed  $default
+	 *
+	 * @return bool
+	 */
+	public function get_property_option( $slug, $option, $default = null ) {
+		$slug     = unpapify( $slug );
+		$property = $this->property( $slug );
+
+		// If no property type is found, return default
+		// value since we don't have a property.
+		if ( ! papi_is_property( $property ) ) {
+			return $default;
+		}
+
+		$value = $property->get_option( $option );
+
+		if ( papi_is_empty( $value ) ) {
+			return $default;
+		}
+
+		return $value;
+	}
+
+	/**
 	 * Prepare load value.
 	 *
 	 * @param  Papi_Core_Property $property

--- a/src/core/class-papi-core-property.php
+++ b/src/core/class-papi-core-property.php
@@ -38,6 +38,7 @@ class Papi_Core_Property {
 		'after_html'    => '',
 		'before_class'  => '',
 		'before_html'   => '',
+		'cache'         => true,
 		'capabilities'  => [],
 		'default'       => null,
 		'description'   => '',

--- a/src/lib/fields/page.php
+++ b/src/lib/fields/page.php
@@ -141,7 +141,11 @@ function papi_get_field( $id = null, $slug = null, $default = null, $type = 'pos
 		return $default;
 	}
 
-	$raw_value = papi_cache_get( $slug, $id, $type );
+	// Determine if we should use the cache or not.
+	$cache = $store->get_property_option( $slug, 'cache', true );
+
+	// Get the raw value from the cache.
+	$raw_value = $cache ? papi_cache_get( $slug, $id, $type ) : false;
 
 	// Load raw value if not cached.
 	if ( $raw_value === null || $raw_value === false ) {
@@ -151,7 +155,11 @@ function papi_get_field( $id = null, $slug = null, $default = null, $type = 'pos
 			return $default;
 		}
 
-		papi_cache_set( $slug, $id, $raw_value, $type );
+		if ( $cache ) {
+			papi_cache_set( $slug, $id, $raw_value, $type );
+		} else {
+			papi_cache_delete( $slug, $id, $type );
+		}
 	}
 
 	if ( papi_is_empty( $raw_value ) ) {

--- a/src/properties/class-papi-property-repeater.php
+++ b/src/properties/class-papi-property-repeater.php
@@ -6,13 +6,6 @@
 class Papi_Property_Repeater extends Papi_Property {
 
 	/**
-	 * Cache child values or not.
-	 *
-	 * @var bool
-	 */
-	protected $cache = false;
-
-	/**
 	 * The convert type.
 	 *
 	 * @var string

--- a/src/types/class-papi-entry-type.php
+++ b/src/types/class-papi-entry-type.php
@@ -310,7 +310,12 @@ class Papi_Entry_Type extends Papi_Core_Type {
 				}
 			}
 
-			return $property;
+			/**
+			 * Modify property.
+			 *
+			 * @param  Papi_Core_Property $property
+			 */
+			return apply_filters( 'papi/get_property', $property );
 		}
 
 		foreach ( $boxes as $box ) {
@@ -319,13 +324,23 @@ class Papi_Entry_Type extends Papi_Core_Type {
 
 				if ( papi_is_property( $property ) && $property->match_slug( $slug ) ) {
 					if ( empty( $child_slug ) ) {
-						return $property;
+						/**
+						 * Modify property.
+						 *
+						 * @param  Papi_Core_Property $property
+						 */
+						return apply_filters( 'papi/get_property', $property );
 					}
 
 					$property = $property->get_child_property( $child_slug );
 
 					if ( papi_is_property( $property ) ) {
-						return $property;
+						/**
+						 * Modify property.
+						 *
+						 * @param  Papi_Core_Property $property
+						 */
+						return apply_filters( 'papi/get_property', $property );
 					}
 				}
 			}

--- a/tests/cases/lib/fields/page-test.php
+++ b/tests/cases/lib/fields/page-test.php
@@ -68,6 +68,25 @@ class Papi_Lib_Fields_Page_Test extends WP_UnitTestCase {
 		$this->assertSame( 'fredrik', papi_get_field( '', 'fredrik' ) );
 	}
 
+	public function test_papi_get_field_cache() {
+		papi_update_property_meta_value( [
+			'id'    => $this->post_id,
+			'slug'  => 'name',
+			'value' => 'fredrik'
+		] );
+		$this->assertSame( 'fredrik', papi_get_field( $this->post_id, 'name' ) );
+		$this->assertSame( 'fredrik', papi_cache_get( 'name', $this->post_id ) );
+
+		// Turn off property cache.
+		add_filter( 'papi/get_property', function ( $property ) {
+			$property->set_option( 'cache', false );
+			return $property;
+		} );
+
+		$this->assertSame( 'fredrik', papi_get_field( $this->post_id, 'name' ) );
+		$this->assertEmpty( papi_cache_get( 'name', $this->post_id ) );
+	}
+
 	public function test_papi_get_slugs() {
 		$this->assertEmpty( papi_get_slugs() );
 


### PR DESCRIPTION
### Description

Adds `cache` option to each property where you can turn off the cache for that property. Repeaters in flexible uses this internally since repeaters otherwise will be cached in a bad way when you have to child repeaters of the same type with the same slug.

The new filter is `papi/get_property` which can modify the property after is loaded from the page type but before it's returned into Papi. `papi/get_boxes` was added to 3.2.0 so I think it's just a good way forward buy adding this filter

### Checklist

- [ ] Bug fix?
- [x] New feature?
- [ ] Deprecations?
- [x] Created tests, if possible

