### PR TITLE
Set default "step" attribute to "any"

### DIFF
--- a/src/properties/class-papi-property-number.php
+++ b/src/properties/class-papi-property-number.php
@@ -52,7 +52,7 @@ class Papi_Property_Number extends Papi_Property {
 		return [
 			'max'  => '',
 			'min'  => '',
-			'step' => '',
+			'step' => 'any',
 			'type' => 'number'
 		];
 	}


### PR DESCRIPTION
### Description

Related to: https://github.com/wp-papi/wp-papi.github.io/pull/22

Allow any kind of number (int, float) by default.