### PR TITLE
Respect id when getting entry type id

### DIFF
--- a/src/admin/class-papi-admin.php
+++ b/src/admin/class-papi-admin.php
@@ -220,10 +220,9 @@ final class Papi_Admin {
 	 * @return array
 	 */
 	public function wp_link_query( array $results ) {
-		$post_type = papi_get_post_type();
-
 		foreach ( $results as $index => $value ) {
-			$name = papi_get_page_type_name( $value['ID'] );
+			$post_type = papi_get_post_type( $value['ID'] );
+			$name      = papi_get_page_type_name( $value['ID'] );
 
 			if ( empty( $name ) ) {
 				$name = papi_filter_settings_standard_page_type_name( $post_type );

--- a/src/lib/types/entry.php
+++ b/src/lib/types/entry.php
@@ -366,10 +366,11 @@ function papi_get_entry_type_id( $id = 0, $type = null ) {
 	 *
 	 * @param  string $entry_type_id
 	 * @param  string $type
+	 * @param  int    $id
 	 *
 	 * @return string
 	 */
-	return apply_filters( 'papi/entry_type_id', $entry_type_id, $type );
+	return apply_filters( 'papi/entry_type_id', $entry_type_id, $type, $id );
 }
 
 /**

--- a/src/lib/types/page.php
+++ b/src/lib/types/page.php
@@ -81,7 +81,7 @@ function papi_get_all_page_types( $post_type = '' ) {
  * @return string
  */
 function papi_get_page_type_id( $post_id = 0 ) {
-	return papi_get_entry_type_id( $post_id );
+	return papi_get_entry_type_id( $post_id, 'post' );
 }
 
 /**
@@ -160,19 +160,21 @@ function papi_is_page_type( $str = '' ) {
  * Load the entry type id on a post types.
  *
  * @param  string $entry_type_id
+ * @param  string $type
+ * @param  int $post_id
  *
  * @return string
  */
-function papi_load_page_type_id( $entry_type_id = '' ) {
-	$key       = papi_get_page_type_key();
-	$post_id   = papi_get_post_id();
-	$post_type = papi_get_post_type( $post_id );
-	$taxonomy  = papi_get_taxonomy();
+function papi_load_page_type_id( $entry_type_id = '', $type = 'post', $post_id = null ) {
+	$type = papi_get_meta_type( $type );
 
-	// Bail if a taxonomy value exists.
-	if ( ! empty( $taxonomy ) ) {
+	if ( $type !== 'post' ) {
 		return $entry_type_id;
 	}
+
+	$post_id   = papi_get_post_id( $post_id );
+	$key       = papi_get_page_type_key();
+	$post_type = papi_get_post_type( $post_id );
 
 	// Try to load the entry type id from only page type filter.
 	if ( empty( $entry_type_id ) ) {
@@ -219,7 +221,7 @@ function papi_load_page_type_id( $entry_type_id = '' ) {
 	return $entry_type_id;
 }
 
-add_filter( 'papi/entry_type_id', 'papi_load_page_type_id' );
+add_filter( 'papi/entry_type_id', 'papi_load_page_type_id', 10, 3 );
 
 /**
  * Set page type to a post.

--- a/tests/cases/admin/class-papi-admin-meta-handler-test.php
+++ b/tests/cases/admin/class-papi-admin-meta-handler-test.php
@@ -113,7 +113,7 @@ class Papi_Admin_Meta_Handler_Test extends WP_UnitTestCase {
 		$this->handler->save_meta_boxes( $revs_id, get_post( $revs_id ) );
 		wp_set_current_user( 0 );
 
-		$this->assertSame( 'Hello, world!', papi_get_field( $revs_id, $property->slug ) );
+		$this->assertSame( 'Hello, world!', get_post_meta( $revs_id, unpapify( $property->slug ), true ) );
 	}
 
 	/**
@@ -138,7 +138,7 @@ class Papi_Admin_Meta_Handler_Test extends WP_UnitTestCase {
 		$this->handler->save_meta_boxes( $post_id, get_post( $post_id ) );
 		wp_set_current_user( 0 );
 
-		$this->assertSame( 'Hello, world!', papi_get_field( $post_id, $property->slug ) );
+		$this->assertSame( 'Hello, world!', get_post_meta( $post_id, unpapify( $property->slug ), true ) );
 	}
 
 	/**
@@ -427,6 +427,8 @@ class Papi_Admin_Meta_Handler_Test extends WP_UnitTestCase {
 
 	public function test_restore_post_revision() {
 		$post_id  = $this->factory->post->create();
+		update_post_meta( $post_id, papi_get_page_type_key(), 'properties-page-type' );
+
 		$revs_id  = wp_save_post_revision( $post_id );
 		$property = $this->page_type->get_property( 'string_test' );
 
@@ -441,13 +443,15 @@ class Papi_Admin_Meta_Handler_Test extends WP_UnitTestCase {
 
 		$_POST['papi_meta_nonce'] = wp_create_nonce( 'papi_save_data' );
 		$_POST['post_ID'] = $revs_id;
+		$_POST[papi_get_page_type_key()] = 'properties-page-type';
 
 		$this->handler->save_meta_boxes( $revs_id, get_post( $revs_id ) );
 		wp_set_current_user( 0 );
 
-		$this->assertSame( 'Hello, world!', papi_get_field( $revs_id, $property->slug ) );
+		$this->assertSame( 'Hello, world!', get_post_meta( $revs_id, unpapify( $property->slug ), true ) );
 
 		$this->handler->restore_post_revision( $post_id, $revs_id );
-		$this->assertSame( 'Hello, world!', papi_get_field( $post_id, $property->slug ) );
+
+		$this->assertSame( 'Hello, world!', get_post_meta( $post_id, unpapify( $property->slug ), true ) );
 	}
 }

--- a/tests/cases/admin/class-papi-admin-test.php
+++ b/tests/cases/admin/class-papi-admin-test.php
@@ -18,7 +18,9 @@ class Papi_Admin_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->admin = new Papi_Admin;
-		$this->post_id = $this->factory->post->create();
+		$this->post_id = $this->factory->post->create( [
+			'post_type' => 'page'
+		] );
 
 		add_filter( 'papi/settings/directories', function () {
 			return [1,  PAPI_FIXTURE_DIR . '/page-types'];

--- a/tests/cases/lib/types/entry-test.php
+++ b/tests/cases/lib/types/entry-test.php
@@ -10,6 +10,9 @@ class Papi_Lib_Types_Entry_Test extends WP_UnitTestCase {
 	public function tearDown() {
 		parent::tearDown();
 		unset( $this->post_id );
+
+		remove_all_filters( 'papi/settings/directories' );
+		papi()->reset();
 	}
 
 	public function test_papi_get_entry_type_body_classes() {

--- a/tests/cases/lib/types/page-test.php
+++ b/tests/cases/lib/types/page-test.php
@@ -147,23 +147,6 @@ class Papi_Lib_Types_Page_Test extends WP_UnitTestCase {
 		unset( $_GET['post_type'] );
 	}
 
-	public function test_papi_get_page_type_id_taxonomy() {
-		$_GET['post_type'] = 'module';
-
-		add_filter( 'papi/settings/only_page_type_module', function () {
-			return 'modules/feature-module-type';
-		} );
-
-		$this->assertSame( 'modules/feature-module-type', papi_get_page_type_id() );
-
-		$_GET['taxonomy'] = 'category';
-
-		$this->assertEmpty( papi_get_page_type_id() );
-
-		unset( $_GET['post_type'] );
-		unset( $_GET['taxonomy'] );
-	}
-
 	public function test_papi_get_page_type_key() {
 		$this->assertSame( '_papi_page_type', papi_get_page_type_key() );
 		$this->assertSame( '_papi_page_type_switch', papi_get_page_type_key( '_switch' ) );

--- a/tests/cases/rest-api/class-papi-rest-api-post-test.php
+++ b/tests/cases/rest-api/class-papi-rest-api-post-test.php
@@ -5,6 +5,11 @@
  */
 class Papi_REST_API_Post_Test extends WP_UnitTestCase {
 
+	/**
+	 * @var Papi_REST_API_Post
+	 */
+	protected $class;
+
 	public function setUp() {
 		parent::setUp();
 
@@ -27,10 +32,13 @@ class Papi_REST_API_Post_Test extends WP_UnitTestCase {
 	}
 
 	public function test_get_page_type() {
-		$post_id = $this->factory->post->create();
+		$post_id = $this->factory->post->create( [
+			'post_type' => 'page'
+		] );
+
 		$page_type = $this->class->get_page_type( ['ID' => $post_id], 'page_type', null );
 
-		$this->assertSame( $page_type, '' );
+		$this->assertSame( '', $page_type );
 		update_post_meta( $post_id, papi_get_page_type_key(), 'simple-content-page-type' );
 
 		$page_type = $this->class->get_page_type( ['ID' => $post_id], 'page_type', null );


### PR DESCRIPTION
### Description

Fixes papi_get_field for specific IDs on certain pages (term archive pages for example)

Also fixes some tests that didn't respect the ID / post type.

### Checklist

- [x] Bug fix?
- [ ] New feature?
- [ ] Deprecations?
- [ ] Created tests, if possible
