### PR TITLE
Fix save revision for custom fields

### DIFF
--- a/src/admin/class-papi-admin-meta-handler.php
+++ b/src/admin/class-papi-admin-meta-handler.php
@@ -140,6 +140,11 @@ final class Papi_Admin_Meta_Handler extends Papi_Core_Data_Handler {
 			return;
 		}
 
+		// Bail if a entry type don't exists on parent post.
+		if ( papi_is_empty( papi_get_entry_type_by_meta_id( $parent_id, 'post' ) ) ) {
+			return;
+		}
+
 		$meta = get_post_meta( $parent_id );
 
 		foreach ( $meta as $key => $value ) {

--- a/src/admin/class-papi-admin-meta-handler.php
+++ b/src/admin/class-papi-admin-meta-handler.php
@@ -130,6 +130,12 @@ final class Papi_Admin_Meta_Handler extends Papi_Core_Data_Handler {
 	 * @param int $post_id
 	 */
 	public function save_revision( $revision_id ) {
+		// Check if our nonce is vailed.
+		if ( ! wp_verify_nonce( papi_get_sanitized_post( 'papi_meta_nonce' ), 'papi_save_data' ) ) {
+			return;
+		}
+
+		// Fetch parent id from revision.
 		if ( ! $parent_id = wp_is_post_revision( $revision_id ) ) {
 			return;
 		}

--- a/src/admin/class-papi-admin-meta-handler.php
+++ b/src/admin/class-papi-admin-meta-handler.php
@@ -134,12 +134,14 @@ final class Papi_Admin_Meta_Handler extends Papi_Core_Data_Handler {
 			return;
 		}
 
-		$slugs = papi_get_slugs( $parent_id, true );
+		$meta = get_post_meta( $parent_id );
 
-		foreach ( $slugs as $slug ) {
-			if ( $value = papi_data_get( $parent_id, $slug ) ) {
-				papi_data_update( $revision_id, $slug, $value );
+		foreach ( $meta as $key => $value ) {
+			if ( $key[0] === '_' && $key !== papi_get_page_type_key() ) {
+				continue;
 			}
+
+			papi_data_update( $revision_id, $key, array_shift( $value ) );
 		}
 	}
 

--- a/tests/cases/admin/class-papi-admin-meta-handler-test.php
+++ b/tests/cases/admin/class-papi-admin-meta-handler-test.php
@@ -455,22 +455,12 @@ class Papi_Admin_Meta_Handler_Test extends WP_UnitTestCase {
 		$revs_id  = wp_save_post_revision( $post_id );
 		$property = $this->page_type->get_property( 'string_test' );
 
-		$_POST = papi_test_create_property_post_data( [
-			'slug'  => $property->slug,
-			'type'  => $property,
-			'value' => 'Hello, world!'
-		], $_POST );
-
-		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
-		wp_set_current_user( $user_id );
+		update_post_meta( $post_id, 'string_test', 'Hello, world!' );
 
 		$_POST['papi_meta_nonce'] = wp_create_nonce( 'papi_save_data' );
-		$_POST['post_ID'] = $revs_id;
-		$_POST[papi_get_page_type_key()] = 'properties-page-type';
 
-		$this->handler->save_meta_boxes( $revs_id, get_post( $revs_id ) );
-		wp_set_current_user( 0 );
+		$this->handler->save_revision( $revs_id );
 
-		$this->assertSame( 'Hello, world!', get_post_meta( $revs_id, unpapify( $property->slug ), true ) );
+		$this->assertSame( 'Hello, world!', get_post_meta( $revs_id, 'string_test', true ) );
 	}
 }

--- a/tests/cases/admin/class-papi-admin-meta-handler-test.php
+++ b/tests/cases/admin/class-papi-admin-meta-handler-test.php
@@ -447,4 +447,30 @@ class Papi_Admin_Meta_Handler_Test extends WP_UnitTestCase {
 
 		$this->assertSame( 'Hello, world!', get_post_meta( $post_id, unpapify( $property->slug ), true ) );
 	}
+
+	public function test_save_revision() {
+		$post_id = $this->factory->post->create();
+		update_post_meta( $post_id, papi_get_page_type_key(), 'properties-page-type' );
+
+		$revs_id  = wp_save_post_revision( $post_id );
+		$property = $this->page_type->get_property( 'string_test' );
+
+		$_POST = papi_test_create_property_post_data( [
+			'slug'  => $property->slug,
+			'type'  => $property,
+			'value' => 'Hello, world!'
+		], $_POST );
+
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+
+		$_POST['papi_meta_nonce'] = wp_create_nonce( 'papi_save_data' );
+		$_POST['post_ID'] = $revs_id;
+		$_POST[papi_get_page_type_key()] = 'properties-page-type';
+
+		$this->handler->save_meta_boxes( $revs_id, get_post( $revs_id ) );
+		wp_set_current_user( 0 );
+
+		$this->assertSame( 'Hello, world!', get_post_meta( $revs_id, unpapify( $property->slug ), true ) );
+	}
 }


### PR DESCRIPTION
### Description

This will fix the issue where Papi fields don't get moved to a revision post. The old code was never triggered so nothing did happen.

### Checklist

- [x] Bug fix?
- [ ] New feature?
- [ ] Deprecations?
- [x] Created tests, if possible
