### PR TITLE
prevent divider property from being saved in post_meta

### DIFF
--- a/src/core/class-papi-core-data-handler.php
+++ b/src/core/class-papi-core-data-handler.php
@@ -170,6 +170,9 @@ class Papi_Core_Data_Handler {
 
 		foreach ( $data as $key => $item ) {
 			if ( papi_is_property_type_key( $key ) ) {
+				if ( isset( $data[$key] ) ) {
+						unset( $data[$key] );
+				}
 				continue;
 			}
 


### PR DESCRIPTION
### Description

Divider properties ended up saving serialized data in post_meta table.

Thanks to @frozzare for pointing to the relevant code!

### Checklist

- [x] Bug fix?
- [ ] New feature?
- [ ] Deprecations?
- [ ] Created tests, if possible
